### PR TITLE
fix how indexation is done to lower dimensional fields

### DIFF
--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -334,8 +334,17 @@ class CartesianOffset(eve.Node):
     def to_dict(self) -> Dict[str, int]:
         return {"i": self.i, "j": self.j, "k": self.k}
 
-    def to_str(self) -> str:
-        return f"i + {self.i}, j + {self.j}, k + {self.k}"
+    def to_str(self, dimensions: tuple[bool, bool, bool]) -> str:
+        dimension_strings = []
+
+        if dimensions[0]:
+            dimension_strings.append(f"i + {self.i}")
+        if dimensions[1]:
+            dimension_strings.append(f"j + {self.j}")
+        if dimensions[2]:
+            dimension_strings.append(f"k + {self.k}")
+
+        return ",".join(dimension_strings)
 
 
 class VariableKOffset(eve.GenericNode, Generic[ExprT]):

--- a/src/gt4py/cartesian/gtc/debug/debug_codegen.py
+++ b/src/gt4py/cartesian/gtc/debug/debug_codegen.py
@@ -104,7 +104,7 @@ class DebugCodeGen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
         symbol_table: dict[str, FieldDecl] = {}
         for declaration in temporary_declarations:
             self.body.append(self.visit(declaration, field_extents=field_extents))
-            symbol_table[declaration.name] = declaration
+            symbol_table[str(declaration.name)] = declaration
         return symbol_table
 
     def generate_field_decls(self, declarations: list[Decl]) -> dict[str, FieldDecl]:
@@ -115,7 +115,7 @@ class DebugCodeGen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
                     f"{declaration.name} = Field({declaration.name}, _origin_['{declaration.name}'], "
                     f"({', '.join([str(x) for x in declaration.dimensions])}))"
                 )
-                symbol_table[declaration.name] = declaration
+                symbol_table[str(declaration.name)] = declaration
         return symbol_table
 
     def generate_run_function(self, stencil: Stencil):
@@ -232,8 +232,8 @@ class DebugCodeGen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
         return f"i, j, {self.visit(absolute_k_index.k)}"
 
     def visit_FieldAccess(self, field_access: FieldAccess, **_) -> str:
-        if field_access.name in self.symbol_table:
-            dimensions = self.symbol_table[field_access.name].dimensions
+        if str(field_access.name) in self.symbol_table:
+            dimensions = self.symbol_table[str(field_access.name)].dimensions
         else:
             dimensions = (True, True, True)
 

--- a/src/gt4py/cartesian/gtc/debug/debug_codegen.py
+++ b/src/gt4py/cartesian/gtc/debug/debug_codegen.py
@@ -223,13 +223,6 @@ class DebugCodeGen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
 
     def visit_CartesianOffset(self, cartesian_offset: CartesianOffset, **kwargs) -> str:
         dimensions = kwargs["dimensions"]
-        # if node.name in kwargs.get("symtable", {}):
-        #     decl = kwargs["symtable"][node.name]
-        #     dimensions = decl.dimensions if isinstance(decl, npir.FieldDecl) else [True] * 3
-        #     offsets = cast(
-        #         Tuple[Optional[int], Optional[int], Union[str, int, npir.AbsoluteKIndex, None]],
-        #         tuple(off if has_dim else None for has_dim, off in zip(dimensions, offsets)),
-        #     )
         return cartesian_offset.to_str(dimensions)
 
     def visit_SymbolRef(self, symbol_ref: SymbolRef) -> str:


### PR DESCRIPTION
## Description

Currently, the OIR describes any offset to a field as a `CartesianOffset` with an `i`, a `j` and a `k` component. Translating this directly into accesses breaks, because lower dimensional fields drop their extra accesses through the `Field` class. 

This PR stores all the `FieldDeclaration`s that we find in the stencil and with a look-up to the dimensionality of the field in there generates the right indexation. 

## Requirements

Before submitting this PR, please make sure:

- [X] The code builds cleanly without new errors or warnings
- [X] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [X] All relevant documentation has been updated or added
