### PR TITLE
fix absolute k access

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,4 +32,3 @@ Delete this comment and add a proper description of the changes contained in thi
 If this PR contains code authored by new contributors please make sure:
 
 - [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,3 +32,4 @@ Delete this comment and add a proper description of the changes contained in thi
 If this PR contains code authored by new contributors please make sure:
 
 - [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
+

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1429,13 +1429,17 @@ class IRMaker(ast.NodeVisitor):
                 "Must be of the form`.at(K=...)`",
                 loc=nodes.Location.from_ast_node(node),
             )
-        if node.keywords[1].arg != "ddim":
+        if len(node.keywords) > 1 and node.keywords[1].arg != "ddim":
             raise GTScriptSyntaxError(
                 message="Absolute K index: bad syntax, second argument (optional) must be `ddim`. "
                 "Must be of the form`.at(K=..., ddim=[...])`",
                 loc=nodes.Location.from_ast_node(node),
             )
-        if node.keywords[1].arg == "ddim" and not isinstance(node.keywords[1].value, ast.List):
+        if (
+            len(node.keywords) > 1
+            and node.keywords[1].arg == "ddim"
+            and not isinstance(node.keywords[1].value, ast.List)
+        ):
             raise GTScriptSyntaxError(
                 message="Absolute K index: bad syntax, second argument `ddim` (optional) must be "
                 "a list of values. Must be of the form`.at(K=..., ddim=[...])`",

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1417,7 +1417,7 @@ class IRMaker(ast.NodeVisitor):
         #           A better version of this code would look through the keywords
         #           in any order. `ddim` shall remain optional, K mandatory.
         assert _filter_absolute_K_index_method(node)
-        if len(node.keywords) != 1 and len(node.keywords) != 2:
+        if len(node.keywords) not in [1, 2]:
             raise GTScriptSyntaxError(
                 message="Absolute K index bad syntax. Must be of the form`.at(K=..., ddim=[...])` "
                 " with the `ddim` argument optional",

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
@@ -362,7 +362,7 @@ def test_this_k_stencil():
 
     @gtscript.stencil(backend="debug")
     def test_stencil(
-        in_field: gtscript.Field[gtscript.K, np.float64],
+        in_field: gtscript.Field[np.float64],
         out_field: gtscript.Field[np.float64],
     ):
         with computation(PARALLEL), interval(...):

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import BACKWARD, PARALLEL, computation, interval, sin
+from gt4py.cartesian.gtscript import BACKWARD, PARALLEL, THIS_K, computation, interval, sin
 
 
 def test_simple_stencil():
@@ -350,3 +350,25 @@ def test_k_only_access_stencil():
     test_stencil(field_in, field_out)
 
     np.testing.assert_allclose(field_out.view(np.ndarray)[1, 1, :], [3, 2, 3, 4])
+
+
+def test_this_k_stencil():
+    field_in = gt_storage.ones(
+        dtype=np.float64, backend="debug", shape=(4, 4, 4), aligned_index=(0, 0, 0)
+    )
+    field_out = gt_storage.zeros(
+        dtype=np.float64, backend="debug", shape=(4, 4, 4), aligned_index=(0, 0, 0)
+    )
+
+    @gtscript.stencil(backend="debug")
+    def test_stencil(
+        in_field: gtscript.Field[gtscript.K, np.float64],
+        out_field: gtscript.Field[np.float64],
+    ):
+        with computation(PARALLEL), interval(...):
+            tmp = THIS_K
+            out_field[0, 0, 0] = in_field.at(K=tmp)
+
+    test_stencil(field_in, field_out)
+
+    np.testing.assert_allclose(field_out.view(np.ndarray)[:, :, 1], 1)


### PR DESCRIPTION
Fix the `.at(K=...)` for support of the new `ddim` optional parameters to index data dimensions, e.g. `.at(K=..., ddim=[...])`