### PR TITLE
Add `.A[]` access for table view support in debug

### DIFF
--- a/src/gt4py/cartesian/gtc/debug/debug_codegen.py
+++ b/src/gt4py/cartesian/gtc/debug/debug_codegen.py
@@ -247,7 +247,10 @@ class DebugCodeGen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
             data_index_access = ",".join(
                 [self.visit(data_index) for data_index in field_access.data_index]
             )
-            full_string = field_access.name + "[" + offset_str + "," + data_index_access + "]"
+            if offset_str == "":
+                full_string = field_access.name + f"[{data_index_access}]"
+            else:
+                full_string = field_access.name + "[" + offset_str + "," + data_index_access + "]"
         else:
             full_string = field_access.name + "[" + offset_str + "]"
         return full_string

--- a/src/gt4py/cartesian/gtc/debug/debug_codegen.py
+++ b/src/gt4py/cartesian/gtc/debug/debug_codegen.py
@@ -247,10 +247,8 @@ class DebugCodeGen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
             data_index_access = ",".join(
                 [self.visit(data_index) for data_index in field_access.data_index]
             )
-            if offset_str == "":
-                full_string = field_access.name + f"[{data_index_access}]"
-            else:
-                full_string = field_access.name + "[" + offset_str + "," + data_index_access + "]"
+            index_str = f"{offset_str},{data_index_access}" if offset_str else data_index_access
+            full_string = f"{field_access.name}[{index_str}]"
         else:
             full_string = field_access.name + "[" + offset_str + "]"
         return full_string

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
@@ -350,3 +350,26 @@ def test_k_only_access_stencil():
     test_stencil(field_in, field_out)
 
     np.testing.assert_allclose(field_out.view(np.ndarray)[1, 1, :], [3, 2, 3, 4])
+
+
+def test_table_access_stencil():
+    table_view = np.ones((4,), dtype=np.float64)
+    field_out = gt_storage.zeros(
+        dtype=np.float64, backend="debug", shape=(4, 4, 4), aligned_index=(0, 0, 0)
+    )
+    table_view[:] = [2, 3, 4, 5]
+
+    @gtscript.stencil(backend="debug")
+    def test_stencil(
+        table_view: gtscript.GlobalTable[(np.float64, (4))],
+        out_field: gtscript.Field[np.float64],
+    ):
+        with computation(PARALLEL):
+            with interval(0, 1):
+                out_field[0, 0, 0] = table_view.A[1]
+            with interval(1, None):
+                out_field[0, 0, 0] = table_view.A[2]
+
+    test_stencil(table_view, field_out)
+
+    np.testing.assert_allclose(field_out.view(np.ndarray)[1, 1, :], [3, 4, 4, 4])


### PR DESCRIPTION
Add the `GlobalTable` feature support for `debug` backend.

Global table is an "off-grid" array that can only be accessed absolutely via data dimensions.