### PR TITLE
remove axis syntax in horizontal regions

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -230,7 +230,7 @@ class HorizontalIntervalParser(IntervalParser):
     @classmethod
     def apply(
         cls,
-        node: Union[ast.Ellipsis, ast.Slice, ast.Subscript, ast.Constant],
+        node: Union[ast.Slice, ast.Subscript, ast.Constant],
         axis_name: str,
         fields: dict[str, nodes.FieldDecl],
         loc: Optional[nodes.Location] = None,
@@ -241,7 +241,7 @@ class HorizontalIntervalParser(IntervalParser):
             slice_node = node
         elif isinstance(getattr(node, "slice", None), ast.Slice):
             # This is the syntax with the inlined slice: K[3:4]
-            slice_node = node.slice
+            raise parser.interval_error
         else:
             # It is a single value and will therefore be (value):(value+1)
             slice_node = cls._slice_from_value(node)
@@ -260,18 +260,8 @@ class HorizontalIntervalParser(IntervalParser):
 
         return nodes.AxisInterval(start=start, end=end, loc=loc)
 
-    def visit_Subscript(self, node: ast.Subscript) -> nodes.AxisBound:
-        # This allows for the syntax
-        # `region[I[0] : I[2], J[0] : J[2]]`
-        # to exist
-        if not isinstance(node.value, ast.Name):
-            raise self.interval_error
-        if node.value.id != self.axis_name:
-            raise self.interval_error
-
-        index = self.visit(node.slice)
-
-        return gtscript.AxisIndex(axis=self.axis_name, index=index)
+    def visit_Subscript(self, _: ast.Subscript) -> None:
+        raise self.interval_error
 
 
 class VerticalIntervalParser(IntervalParser):

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
@@ -450,17 +450,17 @@ def two_optional_fields(
 @register
 def horizontal_regions(field_in: Field3D, field_out: Field3D):
     with computation(PARALLEL), interval(...):
-        with horizontal(region[I[0] : I[2], J[0] : J[2]], region[I[-3] : I[-1], J[-3] : J[-1]]):
+        with horizontal(region[0:2, 0:2], region[-3:-1, -3:-1]):
             field_out = field_in + 1.0
 
-        with horizontal(region[I[0] : I[2], J[-3] : J[-1]], region[I[-3] : I[-1], J[0] : J[2]]):
+        with horizontal(region[0:2, -3:-1], region[-3:-1, 0:2]):
             field_out = field_in - 1.0
 
 
 @register
 def horizontal_region_with_conditional(field_in: Field3D, field_out: Field3D):
     with computation(PARALLEL), interval(...):
-        with horizontal(region[I[0] : I[2], J[0] : J[2]], region[I[-3] : I[-1], J[-3] : J[-1]]):
+        with horizontal(region[0:2, 0:2], region[-3:-1, -3:-1]):
             if field_in > 0:
                 field_out = field_in + 1.0
             else:

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -922,7 +922,7 @@ def test_pruned_args_match(backend):
     def test(out: Field[np.float64], inp: Field[np.float64]):  # type: ignore
         with computation(PARALLEL), interval(...):
             out = 0.0
-            with horizontal(region[I[0] - 1, J[0] - 1]):
+            with horizontal(region[-1:, -1:]):
                 out[0, 0, 0] = inp
 
     inp = gt_storage.zeros(

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -808,7 +808,7 @@ class TestIntervalSyntax:
 class TestRegions:
     def test_one_interval_only(self):
         def stencil(in_f: gtscript.Field[np.float64]):
-            with computation(PARALLEL), interval(...), horizontal(region[I[0:3], :]):
+            with computation(PARALLEL), interval(...), horizontal(region[0:3, :]):
                 in_f = 1.0
 
         def_ir = parse_definition(
@@ -820,7 +820,7 @@ class TestRegions:
 
     def test_one_interval_only_single(self):
         def stencil(in_f: gtscript.Field[np.float64]):
-            with computation(PARALLEL), interval(...), horizontal(region[I[0], :]):
+            with computation(PARALLEL), interval(...), horizontal(region[0, :]):
                 in_f = 1.0
 
         def_ir = parse_definition(
@@ -841,7 +841,7 @@ class TestRegions:
             stencil,
             name=inspect.stack()[0][3],
             module=self.__class__.__name__,
-            externals={"i1": I[1]},
+            externals={"i1": 1},
         )
 
         assert len(def_ir.computations) == 1
@@ -856,7 +856,7 @@ class TestRegions:
         def stencil(in_f: gtscript.Field[np.float64]):
             with computation(PARALLEL), interval(...):
                 in_f = in_f + 1.0
-                with horizontal(region[I[0], :], region[:, J[-1]]):
+                with horizontal(region[0, :], region[:, -1:]):
                     in_f = 1.0
 
         def_ir = parse_definition(
@@ -871,7 +871,7 @@ class TestRegions:
             from gt4py.cartesian.__externals__ import ie
 
             field = 0.0
-            with horizontal(region[ie, :]):
+            with horizontal(region[ie:, :]):
                 field = 1.0
 
             return field
@@ -884,7 +884,7 @@ class TestRegions:
             stencil,
             name=inspect.stack()[0][3],
             module=self.__class__.__name__,
-            externals={"ie": I[-1]},
+            externals={"ie": -1},
         )
 
     def test_error_undefined(self):


### PR DESCRIPTION
This is the PR that removes all the `I[0]` syntax from the horizontal